### PR TITLE
Load FactoryGuy in development

### DIFF
--- a/lib/ember-addon/index.js
+++ b/lib/ember-addon/index.js
@@ -11,19 +11,13 @@ module.exports = {
     this._super.included(app);
 
     // ember-data must be imported before ember-data-factory-guy.
-    var options = {
-      exports: {
-        'ember-data': [
-          'default'
-        ]
-      }
-    };
-
     this.app.import({
+      development: app.bowerDirectory + '/ember-data/ember-data.js',
       test: app.bowerDirectory + '/ember-data/ember-data.js'
-    }, options);
+    }, {exports: {'ember-data': ['default']}});
 
     this.app.import({
+      development: app.bowerDirectory + '/ember-data-factory-guy/dist/ember-data-factory-guy.js',
       test: app.bowerDirectory + '/ember-data-factory-guy/dist/ember-data-factory-guy.js'
     });
   }


### PR DESCRIPTION
Because ember server's /tests endpoint shares vendor.js with the
development environment, FactoryGuy must be included in the development
vendor.js for the tests to pass there.
